### PR TITLE
Add similar cases significance

### DIFF
--- a/ui/app/scripts/controllers/admin/AdminUiSettingsCtrl.js
+++ b/ui/app/scripts/controllers/admin/AdminUiSettingsCtrl.js
@@ -1,7 +1,7 @@
 (function() {
     'use strict';
 
-    angular.module('theHiveControllers').controller('AdminUiSettingsCtrl', function($scope, $q, NotificationSrv, UiSettingsSrv, uiConfig) {
+    angular.module('theHiveControllers').controller('AdminUiSettingsCtrl', function($scope, $q, NotificationSrv, UiSettingsSrv, TagSrv, uiConfig) {
             var self = this;
 
             self.isDirtySetting = function(key, newValue) {
@@ -54,7 +54,7 @@
 
                     self.configs = {};
                     self.settingsKeys.forEach(function(key) {
-                        self.configs[key] = (configs[key] || {}).value;
+                        self.configs[key] = _.clone((configs[key] || {}).value);
                     });
 
                     if(notifyRoot) {
@@ -64,6 +64,9 @@
             };
 
             self.loadSettings(uiConfig);
-
+            
+            self.getTags = function(query) {
+                return TagSrv.fromCases(query);
+            };
         });
 })();

--- a/ui/app/scripts/services/Constants.js
+++ b/ui/app/scripts/services/Constants.js
@@ -33,5 +33,9 @@
                 White: 0
             },
             values: ['White', 'Green', 'Amber', 'Red']
+        })
+        .value('Significance', {
+            Superior: 'Superior',
+            Inferior: 'Inferior'
         });
 })();

--- a/ui/app/scripts/services/UiSettingsSrv.js
+++ b/ui/app/scripts/services/UiSettingsSrv.js
@@ -5,7 +5,8 @@
         var settings = null;
 
         var keys = [
-            'hideEmptyCaseButton'
+            'hideEmptyCaseButton',
+            'inferiorTags'
         ];
 
         var factory = {

--- a/ui/app/views/partials/admin/ui-settings.html
+++ b/ui/app/views/partials/admin/ui-settings.html
@@ -12,9 +12,18 @@
                         <div class="col-md-9">
                             <div class="checkbox">
                                 <label>
-                                  <input name="hideEmptyCaseButton" type="checkbox" ng-model="$vm.configs.hideEmptyCaseButton"> Check this to disallow creating empty cases
+                                    <input name="hideEmptyCaseButton" type="checkbox" ng-model="$vm.configs.hideEmptyCaseButton"> Check this to disallow creating empty cases
                                 </label>
                             </div>
+                        </div>
+                    </div>
+                    
+                    <div class="form-group">
+                        <label class="col-md-3 control-label"><em>Inferior</em> Tags</label>
+                        <div class="col-md-9">
+                            <tags-input name="tagsInput" ng-model="$vm.configs.inferiorTags" class="ti-input-sm" placeholder="Add tags" replace-spaces-with-dashes="false" min-length="2">
+                                <auto-complete min-length="1" debounceDelay="400" source="$vm.getTags($query)"></auto-complete>
+                            </tags-input>
                         </div>
                     </div>
 


### PR DESCRIPTION
Added two additional similar cases tabs in alert preview: 
- _Superior_ - cases which most likely should be considered by the analyst.
- _Inferior_ - cases which most likely should not be considered by the analyst.

If there are no _superior_ / no _inferior_ similar cases, no additional tabs are shown.

Case is marked as _inferior_ if it has at least one _inferior tag_ and _superior_ otherwise.
_Inferior tags_ are defined in UI settings.